### PR TITLE
Build system improvements incl. Windows and cross-build support

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -6,6 +6,13 @@
 	<property name="project.name" value="lbfgsb_wrapper"/>
 	<property name="project.version" value="1.1.3-SNAPSHOT"/>
 	<property name="project.name-ver" value="${project.name}-${project.version}" />
+	<condition property="iswindows" value="1" else="0">
+		<os family="windows"/>
+	</condition>
+	<property name="CC" value="gcc"/>
+	<property name="FC" value="gfortran"/>
+	<property name="LIBGFORTRAN" value="-lgfortran"/>
+	<property name="JNI_ARCH_DIR" value=""/>
 	<!-- Properties } -->
 	
 
@@ -34,7 +41,9 @@
 	<!-- raw_wrapper project {-->
 	<property name="raw_wrapper.dist.dir" location="./raw_wrapper/dist"/>
 	<property name="raw_wrapper.src.dir" location="${raw_wrapper.dist.dir}/src"/>
-	<property name="raw_wrapper.lib.name" value="liblbfgsb_wrapper.so"/>
+	<condition property="raw_wrapper.lib.name" value="liblbfgsb_wrapper.so" else="lbfgsb_wrapper.dll">
+		<equals arg1="${iswindows}" arg2="0"/>
+	</condition>
 
 	<property name="sub-projects.src.dirs" value="${raw_wrapper.src.dir}"/>
 	<!-- raw_wrapper project }-->
@@ -98,6 +107,12 @@
 		<!-- make raw_wrapper library-->
 		<exec executable="make" failonerror="true">
 			<arg value="-C"/> <arg value="raw_wrapper"/>
+			<arg value="WINDOWS=${iswindows}"/>
+			<arg value="CC=${CC}"/>
+			<arg value="FC=${FC}"/>
+			<arg value="LIBGFORTRAN=${LIBGFORTRAN}"/>
+			<arg value="JNI_ARCH_DIR=${JNI_ARCH_DIR}"/>
+			<arg value="LIB_NAME=${raw_wrapper.lib.name}"/>
 		</exec>
 	</target>
 	<!-- Create distribution files in sub-projects }-->

--- a/raw_wrapper/Makefile
+++ b/raw_wrapper/Makefile
@@ -1,5 +1,6 @@
 CC = gcc
 FC = gfortran
+LIBGFORTRAN = -lgfortran
 
 CFLAGS_DEBUG = -fPIC -Wall -g
 CFLAGS_RELEASE = -fPIC -Wall -O3
@@ -8,23 +9,49 @@ FFLAGS_DEBUG = -fPIC -Wall -fexceptions -g
 FFLAGS_RELEASE = -fPIC -Wall -fexceptions -O3
 FFLAGS = $(FFLAGS_RELEASE)
 
+ifeq ($(OS),Windows_NT)
+  WINDOWS = 1
+else
+  ifeq ($(OS),Windows)
+    WINDOWS = 1
+  else
+    WINDOWS = 0
+  endif
+endif
+
+ifeq ($(WINDOWS),0)
+  LIB_NAME = liblbfgsb_wrapper.so
+  JNI_ARCH = linux
+  LDFLAGS = -s -Wl,--version-script=lbfgsb_wrapper.map
+else
+  LIB_NAME = lbfgsb_wrapper.dll
+  JNI_ARCH = win32
+  LDFLAGS = -s -Wl,-kill-at
+endif
+JNI_ARCH_DIR =
+ifeq ($(JNI_ARCH_DIR),)
+  JNI_ARCH_DIR_AUTO = $(JAVA_HOME)/include/$(JNI_ARCH)
+else
+  JNI_ARCH_DIR_AUTO = $(JNI_ARCH_DIR)
+endif
+
 all: dist
 
 init:
 	mkdir -p dist
 	mkdir -p build
 
-dist: init dist/liblbfgsb_wrapper.so dist/test_prog
+dist: init dist/$(LIB_NAME) dist/test_prog
 
-dist/liblbfgsb_wrapper.so: build/lbfgsb_wrapper.o build/solver.o  build/blas.o build/linpack.o build/timer.o lbfgsb_wrapper.i
+dist/$(LIB_NAME): build/lbfgsb_wrapper.o build/solver.o  build/blas.o build/linpack.o build/timer.o lbfgsb_wrapper.i
 	mkdir -p dist/src/lbfgsb/jniwrapper
 	swig -java -package lbfgsb.jniwrapper -outdir dist/src/lbfgsb/jniwrapper lbfgsb_wrapper.i
-	$(CC) -I $(JAVA_HOME)/include -I $(JAVA_HOME)/include/linux -fPIC -c lbfgsb_wrapper_wrap.c -o build/lbfgsb_wrapper_wrap.o #JAVA_HOME environment variable has to be set
-	$(CC) -shared -o dist/liblbfgsb_wrapper.so build/lbfgsb_wrapper_wrap.o build/lbfgsb_wrapper.o build/solver.o build/blas.o build/linpack.o build/timer.o -lm -lgfortran
+	$(CC) -I $(JAVA_HOME)/include -I $(JNI_ARCH_DIR_AUTO) -fPIC -c lbfgsb_wrapper_wrap.c -o build/lbfgsb_wrapper_wrap.o #JAVA_HOME environment variable has to be set
+	$(CC) $(LDFLAGS) -shared -o dist/$(LIB_NAME) build/lbfgsb_wrapper_wrap.o build/lbfgsb_wrapper.o build/solver.o build/blas.o build/linpack.o build/timer.o -lm $(LIBGFORTRAN)
 	
 
 dist/test_prog: build/test_prog.o build/lbfgsb_wrapper.o build/solver.o build/blas.o build/linpack.o build/timer.o
-	$(CC) -o dist/test_prog build/test_prog.o build/lbfgsb_wrapper.o build/solver.o build/blas.o build/linpack.o build/timer.o -lm -lgfortran
+	$(CC) -o dist/test_prog build/test_prog.o build/lbfgsb_wrapper.o build/solver.o build/blas.o build/linpack.o build/timer.o -lm $(LIBGFORTRAN)
 
 build/test_prog.o: test_prog.c
 	$(CC) $(CFLAGS) -c test_prog.c -o build/test_prog.o

--- a/raw_wrapper/lbfgsb_wrapper.map
+++ b/raw_wrapper/lbfgsb_wrapper.map
@@ -1,0 +1,1 @@
+{ global: Java_*; local: *; };


### PR DESCRIPTION
Add support for Windows: use the correct DLL file name, JNI headers and
linker flags (-Wl,--kill-at). Detect Windows hosts both in build.xml and
when invoking the Makefile directly.

Add some variables to build.xml that can be overridden for
cross-compiling (which allows successfully building the binding with
cross-MinGW):
* iswindows is 1 if we want to build for Windows, 0 otherwise (use
  -Diswindows=1 for cross-MinGW builds),
* CC and FC default to gcc and gfortran (respectively) and can be
  overridden with cross compilers,
* LIBGFORTRAN defaults to -lgfortran and can be optionally overridden
  with a static libgfortran if desired,
* JNI_ARCH_DIR can be set to point to architecture-specific JNI headers
  outside of JAVA_HOME (e.g., downloaded from hg.openjdk.java.net) - if
  not set, $(JAVA_HOME)/include/$(JNI_ARCH) is used.

Strip the library by default (-s flag). (At least on GNU/Linux and
Windows, shared libraries can be stripped, because the dynamic symbols
are separate from the debug symbols. As far as I know, Mac OS X does not
allow that though. Mac OS X should probably be detected as Windows is.)

Add a raw_wrapper/lbfgsb_wrapper.map version script that hides non-JNI
symbols on GNU/Linux. Those symbols (especially the BLAS and LINPACK
ones) can cause symbol conflicts, e.g., if the Java library using this
library is loaded into MATLAB. And only the Java_* (JNI) symbols are
actually needed as exports. Note that we do not use -fvisibility=hidden
because GFortran ignores that flag (see
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=35827 ).